### PR TITLE
Build uploaded resource url manually

### DIFF
--- a/docker/dev/dependencies.yml
+++ b/docker/dev/dependencies.yml
@@ -49,7 +49,7 @@ services:
       - 4567:4567
 
   minio:
-    image: minio/minio:RELEASE.2018-07-23T18-34-49Z
+    image: minio/minio:RELEASE.2018-09-01T00-38-25Z
     command: server /data
     volumes:
       - minio-data:/data

--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -152,12 +152,12 @@ async function analyze(linkId, location, options) {
       }
 
       await mongo.db.collection('downloads').insertOne(download)
-      const {Location, ETag} = await upload(bundle, download, previous)
+      const res = await upload(bundle, download, previous)
 
       await mongo.db.collection('downloads').updateOne({_id: download._id}, {
         $set: {
-          url: Location,
-          etag: ETag
+          url: res.location,
+          etag: res.etag
         }
       })
 

--- a/lib/utils/store.js
+++ b/lib/utils/store.js
@@ -1,29 +1,45 @@
 const {S3} = require('aws-sdk')
 const {deburr} = require('lodash')
 
+const S3_ENDPOINT = process.env.S3_ENDPOINT || 'http://localhost:9000'
+
 const client = new S3({
-  endpoint: process.env.S3_ENDPOINT || 'http://localhost:9000',
+  endpoint: S3_ENDPOINT,
   accessKeyId: process.env.S3_ACCESS_KEY || 'minio',
   secretAccessKey: process.env.S3_SECRET_KEY || 'minio-s3cr3t',
-  s3ForcePathStyle: true
+  s3ForcePathStyle: true,
+  signatureVersion: 'v4'
 })
 
-function upload(key, body) {
-  const bucket = process.env.S3_BUCKET || 'link-proxy-files'
+async function upload(key, body) {
+  const bucket = process.env.S3_BUCKET || 'link-proxy'
 
   key = deburr(key)
     .replace(/_/g, '-')
     .replace(/-{2,}/g, '-')
     .toLowerCase()
 
-  return client
-    .upload({
-      ACL: 'public-read',
-      Bucket: bucket,
-      Key: key,
-      Body: body
-    })
-    .promise()
+  try {
+    const result = await client
+      .upload({
+        ACL: 'public-read',
+        Bucket: bucket,
+        Key: key,
+        Body: body
+      })
+      .promise()
+
+    // Rebuild the location instead of using result.Location.
+    // There seems to be an issue when MINIO_DOMAIN (on minio configuration) includes a subdomain.
+    // When that happens, s3ForcePathStyle is not respected and the bucket is used as a subdomain,
+    // as if the request was made as a virtual-host-style request.
+    return {
+      location: `${S3_ENDPOINT}/${bucket}/${result.Key}`,
+      etag: result.Etag
+    }
+  } catch (error) {
+    throw error
+  }
 }
 
 module.exports = {client, upload}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@tusbar/cache-control": "^0.2.1",
-    "aws-sdk": "^2.307.0",
+    "aws-sdk": "^2.311.0",
     "bluebird": "^3.5.1",
     "bull": "^3.4.8",
     "bytes": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,9 +304,9 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
-aws-sdk@^2.307.0:
-  version "2.307.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.307.0.tgz#53a5906d36061d62e7b2ceb243920c7ef8feac97"
+aws-sdk@^2.311.0:
+  version "2.311.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.311.0.tgz#03b0f26f8394352f855ac011f62027b6a9faee5f"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"


### PR DESCRIPTION
There seems to be an issue with minio (or aws-sdk) that makes aws-sdk return a `<bucket>.<domain>` url for some keys (mostly stuff on files.data.gouv.fr).

I manually rebuild the resource’s url in order to always have the bucket included in the path, and not as a subdomain.