### PR TITLE
Prevent duplicated downloads

### DIFF
--- a/__test-helpers__/archive.js
+++ b/__test-helpers__/archive.js
@@ -1,6 +1,6 @@
 const {ZipFile} = require('yazl')
 
-function shapefile(names) {
+function shapefile(names, data = '') {
   const zip = new ZipFile()
 
   if (!Array.isArray(names)) {
@@ -8,11 +8,11 @@ function shapefile(names) {
   }
 
   for (const name of names) {
-    zip.addBuffer(Buffer.from('shp content'), `${name}.shp`)
-    zip.addBuffer(Buffer.from('shx content'), `${name}.shx`)
-    zip.addBuffer(Buffer.from('dbf content'), `${name}.dbf`)
-    zip.addBuffer(Buffer.from('prj content'), `${name}.prj`)
-    zip.addBuffer(Buffer.from('cpg content'), `${name}.cpg`)
+    zip.addBuffer(Buffer.from('shp content' + data), `${name}.shp`)
+    zip.addBuffer(Buffer.from('shx content' + data), `${name}.shx`)
+    zip.addBuffer(Buffer.from('dbf content' + data), `${name}.dbf`)
+    zip.addBuffer(Buffer.from('prj content' + data), `${name}.prj`)
+    zip.addBuffer(Buffer.from('cpg content' + data), `${name}.cpg`)
   }
 
   zip.end()

--- a/__tests__/integration/__snapshots__/zip-shp.js.snap
+++ b/__tests__/integration/__snapshots__/zip-shp.js.snap
@@ -37,3 +37,79 @@ Array [
   },
 ]
 `;
+
+exports[`test-link-proxy-zip-shp should override the downloads if data is different 1`] = `
+Array [
+  Object {
+    "archive": true,
+    "files": Array [
+      Object {
+        "digest": "sha384-+1t5TeJcJ5X34OTBKFd9lDXmWfSP4yyKwNCd6HqLGKChrQodibskoUMz8lbBRABG",
+        "name": "data.shp",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-g/OOiDmdzWdrQElweiK218tYBpzU+Sqpg39YDz/OGKo2bHgTMSfs8PTUFsXaKRtU",
+        "name": "data.cpg",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-N0PxnfQbUbtgRHdg85YR5d23TJyCCw9dkMQ2b7sKrMLplKm2yiK2a+bPBWapI+PA",
+        "name": "data.dbf",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-KjIjW8mDGhYle3IvWHrtMZ3Yng0z3375s8hE8w9gcirOr8Ha1mldECb4q04fg4vc",
+        "name": "data.prj",
+        "size": 11,
+      },
+      Object {
+        "digest": "sha384-FA1fzHfLn30z4w1QOE8IM3GlS45Xvmodk+MQdzWCkx8ceyOzE3aLBV9Gl7XXZJ4e",
+        "name": "data.shx",
+        "size": 11,
+      },
+    ],
+    "name": "data.shp",
+    "path": "data.zip/data.shp",
+    "type": "shp",
+  },
+]
+`;
+
+exports[`test-link-proxy-zip-shp should override the downloads if data is different 2`] = `
+Array [
+  Object {
+    "archive": true,
+    "files": Array [
+      Object {
+        "digest": "sha384-Q5kepNea0+a2WqPdU2MxpoawNnQ0hu4ZviVXuaVHeNn3EqEyX+MoiEpYpiOZjBTX",
+        "name": "data.shp",
+        "size": 14,
+      },
+      Object {
+        "digest": "sha384-aAbsiN9W7hqamx9KmjF/0+rPfKfsWBLYeI2enYTd3FNIjMqbYkjVj2BIjydrPwHZ",
+        "name": "data.cpg",
+        "size": 14,
+      },
+      Object {
+        "digest": "sha384-/ZaF7xVUzPJnIjlTrmv5sA513A8rQrnUx4s5iJzrSZ12v+MptyCqenaUubg24ouI",
+        "name": "data.dbf",
+        "size": 14,
+      },
+      Object {
+        "digest": "sha384-9V/3an5UYvsUo7I2ppmZ/GHGJklwuYZLnOe1yWgo89lREz7+DTBnCvOqPHeiFQj9",
+        "name": "data.prj",
+        "size": 14,
+      },
+      Object {
+        "digest": "sha384-u6yp4o4JDqAu4lIPMGzJyF/daH7V+4HHBR1sH4XNAOHQv1zRwlYJ5ZESAxTGZjEH",
+        "name": "data.shx",
+        "size": 14,
+      },
+    ],
+    "name": "data.shp",
+    "path": "data.zip/data.shp",
+    "type": "shp",
+  },
+]
+`;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,13 +2,36 @@ const store = require('./lib/utils/store')
 
 const BUCKET = 'test-link-proxy-files'
 const DB = 'test-link-proxy'
+const BUCKET_POLICY = `
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"AddPerm",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject"],
+      "Resource":[
+        "arn:aws:s3:::${BUCKET}/*"
+      ]
+    }
+  ]
+}
+`
 
 async function setup() {
   process.env.S3_BUCKET = BUCKET
   process.env.MONGO_DB = DB
 
   try {
-    await store.client.createBucket({Bucket: BUCKET}).promise()
+    await store.client.createBucket({
+      Bucket: BUCKET
+    }).promise()
+
+    await store.client.putBucketPolicy({
+      Bucket: BUCKET,
+      Policy: BUCKET_POLICY
+    }).promise()
   } catch (error) {
     console.error(`\n\nThe bucket "${BUCKET}" already exists, we’re re-using it, tests may fail.\n`)
   }


### PR DESCRIPTION
Also fix an exception where a previous download wouldn’t have an url.

Fix #134