### PR TITLE
Redirect to a non running check in last check route

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $ curl localhost:5000/5aa167645d88a1a73a42995e/checks/1
 ```
 ### `GET /:linkId/checks/latest`
 
-Find the latest check for a link. It will redirect (302) to the matching check, if found.
+Find the latest non-running check for a link. It will redirect (302) to the matching check, if found.
 
 **Example**
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const mongo = require('./lib/utils/mongo')
 const queues = require('./lib/utils/queues')
 
 const {findLink, upsertLink, getLinkSummary} = require('./lib/link')
-const {getLinkChecks, getLinkCheck, findLastCheck} = require('./lib/check')
+const {getLinkChecks, getLinkCheck, findLastNonRunningCheck} = require('./lib/check')
 
 function handleErrors(next) {
   return async (req, res) => {
@@ -50,7 +50,7 @@ const routes = router(
   }),
 
   get('/:link/checks/latest', async (req, res) => {
-    const check = await findLastCheck(req.params.link)
+    const check = await findLastNonRunningCheck(req.params.link)
 
     if (!check) {
       throw micro.createError(404, `latest check for link ${req.params.link} was not found`)

--- a/lib/check.js
+++ b/lib/check.js
@@ -69,14 +69,20 @@ function getLinkCheck(linkId, checkNumber) {
   })
 }
 
-function findLastCheck(linkId) {
+function findLastNonRunningCheck(linkId) {
   const objectId = mongo.parseObjectID(linkId)
   if (!objectId) {
     return null
   }
 
   return mongo.db.collection('checks').findOne({
-    linkId: objectId
+    linkId: objectId,
+    state: {
+      $nin: [
+        'started',
+        'analyzing'
+      ]
+    }
   }, {
     projection: {
       _id: 0,
@@ -88,4 +94,4 @@ function findLastCheck(linkId) {
   })
 }
 
-module.exports = {getLinkChecks, getLinkCheck, findLastCheck}
+module.exports = {getLinkChecks, getLinkCheck, findLastNonRunningCheck}

--- a/lib/utils/mongo/indexes.js
+++ b/lib/utils/mongo/indexes.js
@@ -41,6 +41,19 @@ module.exports = {
       }
     },
 
+    // Allow faster lookups when retrieving a link’s last non-running check.
+    {
+      collection: 'checks',
+      fieldOrSpec: {
+        linkId: 1,
+        number: 1,
+        state: 1
+      },
+      options: {
+        name: 'linkId_number_state_1'
+      }
+    },
+
     // Collection: files
     // =================
     // Allow faster lookups when retrieving file cache.


### PR DESCRIPTION
Add index to speed up this query.

`started` and `analyzing` are the only two *running* states.