### PR TITLE
Fix related match

### DIFF
--- a/__tests__/unit/check/__fixtures__/HYD_ZON_BassVers_Rade_compl_s.json
+++ b/__tests__/unit/check/__fixtures__/HYD_ZON_BassVers_Rade_compl_s.json
@@ -1,0 +1,240 @@
+{
+  "inputType": "http",
+  "url": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+  "statusCode": 200,
+  "redirectUrls": [],
+  "finalUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+  "etag": "\"3b3b329cc05ad41:0\"",
+  "lastModified": "Wed, 03 Oct 2018 02:27:20 GMT",
+  "fileName": "HYD_ZON_BassVers_Rade_compl_s.zip",
+  "fileTypes": [
+    {
+      "ext": false,
+      "mime": "application/x-zip-compressed",
+      "source": "http:content-type"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "http:filename"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "path:chunk"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "path:filename"
+    }
+  ],
+  "temporary": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug",
+  "fileSize": 394333,
+  "digest": "sha384-ji+83Tr2nS8EXshEJpmikDn+XsGrKO2WT9TQMcNsGJb3K0Drl2InEpBnKzgJMG3x",
+  "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/HYD_ZON_BassVers_Rade_compl_s.zip",
+  "type": "archive",
+  "children": [
+    {
+      "inputType": "path",
+      "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived",
+      "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip",
+      "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+      "type": "directory",
+      "children": [
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.cpg",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.cpg",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.cpg",
+          "fileTypes": [
+            {
+              "ext": "cpg",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-yrZQ9NCRVOcfAB1mtzjinEi2XP1B2g3NkXaQ59S0R8Oh8HevZUR6dq960k5Y29Gw",
+          "fileSize": 5,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.dbf",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.dbf",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.dbf",
+          "fileTypes": [
+            {
+              "ext": "dbf",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-HNgRMoBEqK3/SI3LJVuUTdEYluGIUNYKKtLC/B1Al8KGCZOcjiRrsd7/uuKjezRm",
+          "fileSize": 9122,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.lyr",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.lyr",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.lyr",
+          "fileTypes": [
+            {
+              "ext": "msi",
+              "mime": "application/x-msi",
+              "source": "path:chunk"
+            },
+            {
+              "ext": "lyr",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-l0OBnMIirew9MrhR0OcJh1WZEuMd2k+h1eRVu3f4mxW7L2Gu0UVY8LOUX/nEXbna",
+          "fileSize": 7680,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.pdf",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.pdf",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.pdf",
+          "fileTypes": [
+            {
+              "ext": "pdf",
+              "mime": "application/pdf",
+              "source": "path:chunk"
+            },
+            {
+              "ext": "pdf",
+              "mime": "application/pdf",
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-42ytPduwa/qtWDIUK+ldw/rfi1ZOITDJmIknCyKIZous7//KS/OLErs4IRuE6DHQ",
+          "fileSize": 240401,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.prj",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.prj",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.prj",
+          "fileTypes": [
+            {
+              "ext": "prj",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-Nbb1qvYtn5QKJpEZXaMOurKSMOK/v8g2IQTG25BoNQIJ+iEk0vWEo89AP9jpchoa",
+          "fileSize": 452,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.sbn",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.sbn",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.sbn",
+          "fileTypes": [
+            {
+              "ext": "sbn",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-OrdG6F1SvjqHRy32JPmuyQ/lpMwxgA022zFC495OrcUEBDTN+IQApiVolj/jysci",
+          "fileSize": 1100,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.sbx",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.sbx",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.sbx",
+          "fileTypes": [
+            {
+              "ext": "sbx",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-HzSR2zoMgAI3ERb6eqv3Q+vVSGqnPp4i37gozO7CSXMymZFFy5uRrw29TV/VlSlh",
+          "fileSize": 212,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shp",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shp",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.shp",
+          "fileTypes": [
+            {
+              "ext": "shp",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-a81Czi0DMyjdFLO2qDKJj4WM9RdSPsH301M/oTcWclPXT+lzIHQe6OkXxP3fqtHA",
+          "fileSize": 232164,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+          "fileTypes": [
+            {
+              "ext": "xml",
+              "mime": "application/xml",
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-l0/ZWOc8uKD4ltaKQVcz7Yg3r05QBAJGxWAnAcgyd5lD8tzbMBcIvJezQiv1lgQ0",
+          "fileSize": 15029,
+          "type": "file",
+          "analyzed": true
+        },
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shx",
+          "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shx",
+          "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+          "fileName": "HYD_ZON_BassVers_Rade_compl_s.shx",
+          "fileTypes": [
+            {
+              "ext": "shx",
+              "mime": false,
+              "source": "path:filename"
+            }
+          ],
+          "digest": "sha384-EpxwLDdYG9mDRaeldP4EXAYa0+g8scEbgheOexa6bp7wOxg1vWXzrTBJkKidR3Ji",
+          "fileSize": 868,
+          "type": "file",
+          "analyzed": true
+        }
+      ],
+      "analyzed": true
+    }
+  ],
+  "analyzed": true
+}

--- a/__tests__/unit/check/__fixtures__/N_PERIM_MAET_ZINF_S_R53_2009.json
+++ b/__tests__/unit/check/__fixtures__/N_PERIM_MAET_ZINF_S_R53_2009.json
@@ -1,0 +1,153 @@
+{
+  "inputType": "http",
+  "url": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+  "statusCode": 200,
+  "redirectUrls": [],
+  "finalUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+  "fileName": "dataset-1538645795676.zip",
+  "fileTypes": [
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "http:content-type"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "http:filename"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "path:chunk"
+    },
+    {
+      "ext": "zip",
+      "mime": "application/zip",
+      "source": "path:filename"
+    }
+  ],
+  "temporary": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2",
+  "fileSize": 2136059,
+  "digest": "sha384-nKE3iPtBCWW8QFWEcFMVpOwjA3VSLE3Ozr7ExBezIdnd2Y3X+VCVbuFowGJ9/Swz",
+  "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/dataset-1538645795676.zip",
+  "type": "archive",
+  "children": [
+    {
+      "inputType": "path",
+      "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived",
+      "filePath": "dataset-1538645795676.zip",
+      "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+      "type": "directory",
+      "children": [
+        {
+          "inputType": "path",
+          "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset",
+          "filePath": "dataset-1538645795676.zip/dataset",
+          "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+          "type": "directory",
+          "children": [
+            {
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "fileTypes": [
+                {
+                  "ext": "DAT",
+                  "mime": false,
+                  "source": "path:filename"
+                }
+              ],
+              "digest": "sha384-Z780GZB5hptF9ANSpEEp30oN9O1EoHrKkoZXSAIE4PthCKxCJDAR2kgIFeM9o4Pw",
+              "fileSize": 12912,
+              "type": "file",
+              "analyzed": true
+            },
+            {
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "fileTypes": [
+                {
+                  "ext": "ID",
+                  "mime": false,
+                  "source": "path:filename"
+                }
+              ],
+              "digest": "sha384-9GJxVM1/ARRIfMqjy+FPQeOpvK39S0prtUHyZzl/VagqXlBOuVXDcIaiLS9snPcT",
+              "fileSize": 300,
+              "type": "file",
+              "analyzed": true
+            },
+            {
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "fileTypes": [
+                {
+                  "ext": "MAP",
+                  "mime": "application/json",
+                  "source": "path:filename"
+                }
+              ],
+              "digest": "sha384-TWSCOZ85t5wXpcFAlC1inpzrUp7x053BYIxPcai1bsimSuFV7ThFAUpK553LrrMF",
+              "fileSize": 2560000,
+              "type": "file",
+              "analyzed": true
+            },
+            {
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "fileTypes": [
+                {
+                  "ext": "TAB",
+                  "mime": false,
+                  "source": "path:filename"
+                }
+              ],
+              "digest": "sha384-NbvX0wBc0CPcajtZ/SHaVn6fa/p+4UrPiko110mTD5jLLtCb6oEnEg7BbZhNHl2q",
+              "fileSize": 446,
+              "type": "file",
+              "analyzed": true
+            },
+            {
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+              "filePath": "dataset-1538645795676.zip/dataset/fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "fileName": "fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+              "fileTypes": [
+                {
+                  "ext": "xml",
+                  "mime": "application/xml",
+                  "source": "path:chunk"
+                },
+                {
+                  "ext": "xml",
+                  "mime": "application/xml",
+                  "source": "path:filename"
+                }
+              ],
+              "digest": "sha384-gKKOWZTkRXrvTqxwWMjBHASy2BnFJk25+60zDW18WDpHwqfBd/0ga369bbaH8tQ6",
+              "fileSize": 26309,
+              "type": "file",
+              "analyzed": true
+            }
+          ],
+          "analyzed": true
+        }
+      ],
+      "analyzed": true
+    }
+  ],
+  "analyzed": true
+}

--- a/__tests__/unit/check/__snapshots__/flatten.js.snap
+++ b/__tests__/unit/check/__snapshots__/flatten.js.snap
@@ -1,5 +1,345 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`check.flatten should correctly process HYD_ZON_BassVers_Rade_compl_s 1`] = `
+Object {
+  "ignored": Array [],
+  "links": Object {
+    "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip": Object {
+      "bundles": Array [
+        Object {
+          "changed": 9,
+          "files": Array [
+            Object {
+              "analyzed": true,
+              "digest": "sha384-a81Czi0DMyjdFLO2qDKJj4WM9RdSPsH301M/oTcWclPXT+lzIHQe6OkXxP3fqtHA",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.shp",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shp",
+              "fileSize": 232164,
+              "fileTypes": Array [
+                Object {
+                  "ext": "shp",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shp",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-yrZQ9NCRVOcfAB1mtzjinEi2XP1B2g3NkXaQ59S0R8Oh8HevZUR6dq960k5Y29Gw",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.cpg",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.cpg",
+              "fileSize": 5,
+              "fileTypes": Array [
+                Object {
+                  "ext": "cpg",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.cpg",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-HNgRMoBEqK3/SI3LJVuUTdEYluGIUNYKKtLC/B1Al8KGCZOcjiRrsd7/uuKjezRm",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.dbf",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.dbf",
+              "fileSize": 9122,
+              "fileTypes": Array [
+                Object {
+                  "ext": "dbf",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.dbf",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-l0OBnMIirew9MrhR0OcJh1WZEuMd2k+h1eRVu3f4mxW7L2Gu0UVY8LOUX/nEXbna",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.lyr",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.lyr",
+              "fileSize": 7680,
+              "fileTypes": Array [
+                Object {
+                  "ext": "msi",
+                  "mime": "application/x-msi",
+                  "source": "path:chunk",
+                },
+                Object {
+                  "ext": "lyr",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.lyr",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-Nbb1qvYtn5QKJpEZXaMOurKSMOK/v8g2IQTG25BoNQIJ+iEk0vWEo89AP9jpchoa",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.prj",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.prj",
+              "fileSize": 452,
+              "fileTypes": Array [
+                Object {
+                  "ext": "prj",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.prj",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-OrdG6F1SvjqHRy32JPmuyQ/lpMwxgA022zFC495OrcUEBDTN+IQApiVolj/jysci",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.sbn",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.sbn",
+              "fileSize": 1100,
+              "fileTypes": Array [
+                Object {
+                  "ext": "sbn",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.sbn",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-HzSR2zoMgAI3ERb6eqv3Q+vVSGqnPp4i37gozO7CSXMymZFFy5uRrw29TV/VlSlh",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.sbx",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.sbx",
+              "fileSize": 212,
+              "fileTypes": Array [
+                Object {
+                  "ext": "sbx",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.sbx",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-l0/ZWOc8uKD4ltaKQVcz7Yg3r05QBAJGxWAnAcgyd5lD8tzbMBcIvJezQiv1lgQ0",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+              "fileSize": 15029,
+              "fileTypes": Array [
+                Object {
+                  "ext": "xml",
+                  "mime": "application/xml",
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shp.xml",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-EpxwLDdYG9mDRaeldP4EXAYa0+g8scEbgheOexa6bp7wOxg1vWXzrTBJkKidR3Ji",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.shx",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.shx",
+              "fileSize": 868,
+              "fileTypes": Array [
+                Object {
+                  "ext": "shx",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.shx",
+              "type": "file",
+            },
+          ],
+          "type": "shp",
+        },
+        Object {
+          "changed": 1,
+          "files": Array [
+            Object {
+              "analyzed": true,
+              "digest": "sha384-42ytPduwa/qtWDIUK+ldw/rfi1ZOITDJmIknCyKIZous7//KS/OLErs4IRuE6DHQ",
+              "fileName": "HYD_ZON_BassVers_Rade_compl_s.pdf",
+              "filePath": "HYD_ZON_BassVers_Rade_compl_s.zip/HYD_ZON_BassVers_Rade_compl_s.pdf",
+              "fileSize": 240401,
+              "fileTypes": Array [
+                Object {
+                  "ext": "pdf",
+                  "mime": "application/pdf",
+                  "source": "path:chunk",
+                },
+                Object {
+                  "ext": "pdf",
+                  "mime": "application/pdf",
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "https://applications002.brest-metropole.fr/VIPDU72/GPB/HYD_ZON_BassVers_Rade_compl_s.zip",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug/_unarchived/HYD_ZON_BassVers_Rade_compl_s.pdf",
+              "type": "file",
+            },
+          ],
+          "type": "document",
+        },
+      ],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+  },
+  "temporaries": Array [
+    "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_cCZ3Ug",
+  ],
+}
+`;
+
+exports[`check.flatten should correctly process N_PERIM_MAET_ZINF_S_R53_2009 1`] = `
+Object {
+  "ignored": Array [
+    Object {
+      "analyzed": true,
+      "digest": "sha384-gKKOWZTkRXrvTqxwWMjBHASy2BnFJk25+60zDW18WDpHwqfBd/0ga369bbaH8tQ6",
+      "fileName": "fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+      "filePath": "dataset-1538645795676.zip/dataset/fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+      "fileSize": 26309,
+      "fileTypes": Array [
+        Object {
+          "ext": "xml",
+          "mime": "application/xml",
+          "source": "path:chunk",
+        },
+        Object {
+          "ext": "xml",
+          "mime": "application/xml",
+          "source": "path:filename",
+        },
+      ],
+      "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+      "inputType": "path",
+      "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/fr-120066022-jdd-c4fe283f-abce-4c2e-b75f-8ee82fb78cf5.xml",
+      "type": "file",
+    },
+  ],
+  "links": Object {
+    "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset": Object {
+      "bundles": Array [
+        Object {
+          "changed": 4,
+          "files": Array [
+            Object {
+              "analyzed": true,
+              "digest": "sha384-NbvX0wBc0CPcajtZ/SHaVn6fa/p+4UrPiko110mTD5jLLtCb6oEnEg7BbZhNHl2q",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "fileSize": 446,
+              "fileTypes": Array [
+                Object {
+                  "ext": "TAB",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.TAB",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-Z780GZB5hptF9ANSpEEp30oN9O1EoHrKkoZXSAIE4PthCKxCJDAR2kgIFeM9o4Pw",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "fileSize": 12912,
+              "fileTypes": Array [
+                Object {
+                  "ext": "DAT",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.DAT",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-9GJxVM1/ARRIfMqjy+FPQeOpvK39S0prtUHyZzl/VagqXlBOuVXDcIaiLS9snPcT",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "fileSize": 300,
+              "fileTypes": Array [
+                Object {
+                  "ext": "ID",
+                  "mime": false,
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.ID",
+              "type": "file",
+            },
+            Object {
+              "analyzed": true,
+              "digest": "sha384-TWSCOZ85t5wXpcFAlC1inpzrUp7x053BYIxPcai1bsimSuFV7ThFAUpK553LrrMF",
+              "fileName": "N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "filePath": "dataset-1538645795676.zip/dataset/N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "fileSize": 2560000,
+              "fileTypes": Array [
+                Object {
+                  "ext": "MAP",
+                  "mime": "application/json",
+                  "source": "path:filename",
+                },
+              ],
+              "fromUrl": "http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset",
+              "inputType": "path",
+              "path": "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2/_unarchived/dataset/N_PERIM_MAET_ZINF_S_R53_2009.MAP",
+              "type": "file",
+            },
+          ],
+          "type": "tab",
+        },
+      ],
+      "errors": Array [],
+      "urls": Array [],
+      "warnings": Array [],
+    },
+  },
+  "temporaries": Array [
+    "/var/folders/wb/4xx5dj9j0r12lym3mgxhj0l00000gn/T/plunger_uhyNu2",
+  ],
+}
+`;
+
 exports[`check.flatten should flatten a shapefile in an index-of 1`] = `
 Object {
   "ignored": Array [],

--- a/__tests__/unit/check/flatten.js
+++ b/__tests__/unit/check/flatten.js
@@ -112,4 +112,16 @@ describe('check.flatten', () => {
 
     expect(res).toMatchSnapshot()
   })
+
+  it('should correctly process N_PERIM_MAET_ZINF_S_R53_2009', () => {
+    expect(
+      flatten(require('./__fixtures__/N_PERIM_MAET_ZINF_S_R53_2009.json'))
+    ).toMatchSnapshot()
+  })
+
+  it('should correctly process HYD_ZON_BassVers_Rade_compl_s', () => {
+    expect(
+      flatten(require('./__fixtures__/HYD_ZON_BassVers_Rade_compl_s.json'))
+    ).toMatchSnapshot()
+  })
 })

--- a/__tests__/unit/lib/utils/filename.js
+++ b/__tests__/unit/lib/utils/filename.js
@@ -1,0 +1,79 @@
+const {getPossibleExtensions} = require('../../../../lib/utils/filename')
+
+describe('check.utils.filename', () => {
+  it('should return an empty array for extensionless filenames', () => {
+    expect(
+      getPossibleExtensions('foobar')
+    ).toEqual([])
+  })
+
+  it('should return an empty array for filenames ending with dots', () => {
+    expect(
+      getPossibleExtensions('foobar.')
+    ).toEqual([])
+
+    expect(
+      getPossibleExtensions('foobar....')
+    ).toEqual([])
+  })
+
+  it('should return the extension for a simple filename', () => {
+    expect(
+      getPossibleExtensions('a-cool-csv.csv')
+    ).toEqual([{
+      name: 'a-cool-csv',
+      ext: 'csv'
+    }])
+
+    expect(
+      getPossibleExtensions('a.ext')
+    ).toEqual([{
+      name: 'a',
+      ext: 'ext'
+    }])
+
+    expect(
+      getPossibleExtensions('a.a')
+    ).toEqual([{
+      name: 'a',
+      ext: 'a'
+    }])
+  })
+
+  it('should not consider a hidden file as an extension', () => {
+    expect(
+      getPossibleExtensions('.foobar')
+    ).toEqual([])
+  })
+
+  it('should return a hidden file’s extension', () => {
+    expect(
+      getPossibleExtensions('.foobar.txt')
+    ).toEqual([{
+      name: '.foobar',
+      ext: 'txt'
+    }])
+  })
+
+  it('should return multiple entries for potential composed extensions', () => {
+    expect(
+      getPossibleExtensions('a-complicated-extension.txt.gz')
+    ).toEqual([{
+      name: 'a-complicated-extension.txt',
+      ext: 'gz'
+    }, {
+      name: 'a-complicated-extension',
+      ext: 'txt.gz'
+    }])
+
+    expect(
+      getPossibleExtensions('.hidden.SHP.xml')
+    ).toEqual([{
+      name: '.hidden.SHP',
+      ext: 'xml'
+    }, {
+      name: '.hidden',
+      ext: 'SHP.xml'
+    }])
+  })
+})

--- a/jobs/check/flatten.js
+++ b/jobs/check/flatten.js
@@ -1,14 +1,25 @@
-const {extname} = require('path')
 const {remove} = require('lodash')
 
 const fileTypes = require('../../lib/types')
+const {getPossibleExtensions} = require('../../lib/utils/filename')
 
 function getRelated(tokens, token, type) {
-  return tokens.filter(t => {
-    const ext = extname(token.fileName).substring(1)
-    const extensionless = token.fileName.slice(0, -ext.length - 1)
+  const main = getPossibleExtensions(token.fileName).find(({ext}) => {
+    const lext = ext.toLowerCase()
 
-    return type.related.some(ext => t.fileName === `${extensionless}.${ext}`)
+    return type.extensions.some(e => e === lext)
+  })
+
+  return tokens.filter(t => {
+    const comp = getPossibleExtensions(t.fileName).find(
+      ({name}) => name === main.name
+    )
+
+    if (!comp) {
+      return false
+    }
+
+    return type.related.some(r => r === comp.ext.toLowerCase())
   })
 }
 

--- a/lib/utils/filename.js
+++ b/lib/utils/filename.js
@@ -1,0 +1,30 @@
+const {parse} = require('path')
+
+function getPossibleExtensions(fileName) {
+  const result = []
+
+  let found = false
+  let ext = ''
+
+  do {
+    const parsed = parse(fileName)
+    if (parsed.ext.length === 0 || parsed.ext === '.') {
+      break
+    }
+
+    found = true
+    fileName = parsed.name
+    ext = parsed.ext + ext
+
+    result.push({
+      name: parsed.name,
+      ext: ext.substring(1)
+    })
+  } while (found)
+
+  return result
+}
+
+module.exports = {
+  getPossibleExtensions
+}


### PR DESCRIPTION
The match was completely wrong.

Add a real life fixture to enhance the tests.
This makes sure that different extension cases are matched as well.

Add utility to find all possible extensions on a filename. This allows us to match extensions like `.shp.xml` and alike.

foo.shp + FOO.cpg will not be considered as related. Maybe this should be the case, what do you think @jdesboeufs ? If it does, will fix in another PR.
