### PR TITLE
Fix duplicated downloads

### DIFF
--- a/jobs/check/index.js
+++ b/jobs/check/index.js
@@ -143,7 +143,7 @@ async function analyze(linkId, location, options) {
             $in: subLink.downloads
           },
           type: bundle.type,
-          path: mainFile.filePath
+          name: mainFile.fileName
         }, {
           sort: {
             createdAt: -1

--- a/lib/utils/mongo/indexes.js
+++ b/lib/utils/mongo/indexes.js
@@ -69,6 +69,19 @@ module.exports = {
       }
     },
 
+    // Collection: downloads
+    // =====================
+    // Allow faster sorts
+    {
+      collection: 'downloads',
+      fieldOrSpec: {
+        createdAt: 1
+      },
+      options: {
+        name: 'createdAt_1'
+      }
+    },
+
     // Collection: subscribers
     // =======================
     // Make sure that there are no duplicates.


### PR DESCRIPTION
http://atom.geo-ide.developpement-durable.gouv.fr/atomArchive/GetResource?id=29e549c8-cd91-4e09-8750-941db34dc916&dataType=dataset generates a zip file with a timestamp in its name (`dataset-1537951791413.zip`), causing the dedup mechanism to fail.

We’re comparing filenames now. This could probably fail in some rare edge cases and delete a little too much when there are duplicate filenames in a sublink. Even though I don’t think that it should cause much harm, we could, eventually, add something that compares hashes.

Also add an index on `createdAt` of the `downloads` collection to allow faster sorts.