### PR TITLE
Skip checks if last finished check is not older than 7 days

### DIFF
--- a/__tests__/integration/zip-shp.js
+++ b/__tests__/integration/zip-shp.js
@@ -78,7 +78,10 @@ describe(NAME, () => {
     await check.handler({
       data: {
         linkId: _id,
-        location: url
+        location: url,
+        options: {
+          noCache: true
+        }
       }
     })
 

--- a/__tests__/unit/jobs/check/__snapshots__/check.js.snap
+++ b/__tests__/unit/jobs/check/__snapshots__/check.js.snap
@@ -7,7 +7,7 @@ Object {
   "linkId": Any<ObjectID>,
   "location": "http://example.org/1",
   "number": 1,
-  "options": undefined,
+  "options": Object {},
   "state": "started",
   "updatedAt": Any<Date>,
 }

--- a/__tests__/unit/jobs/check/check.js
+++ b/__tests__/unit/jobs/check/check.js
@@ -66,7 +66,7 @@ describe('jobs.check.check', () => {
       cacheControl: 'max-age=1234567890'
     }
 
-    const check = await createCheck(link, 'http://example.org/4', {})
+    const check = await createCheck(link, 'http://example.org/4')
 
     expect(check.state).toBe('started')
   })
@@ -80,10 +80,11 @@ describe('jobs.check.check', () => {
     await mongo.db.collection('checks').insertOne({
       createdAt: new Date(),
       linkId: link._id,
+      state: 'finished',
       location: 'http://example.org/5'
     })
 
-    const check = await createCheck(link, 'http://example.org/5', {})
+    const check = await createCheck(link, 'http://example.org/5')
 
     expect(check.state).toBe('skipped')
   })
@@ -123,7 +124,7 @@ describe('jobs.check.check', () => {
       setTimeout(() => resolve(), 2000)
     })
 
-    const check = await createCheck(link, 'http://example.org/7', {})
+    const check = await createCheck(link, 'http://example.org/7')
 
     expect(check.state).toBe('started')
   })
@@ -137,6 +138,7 @@ describe('jobs.check.check', () => {
     await mongo.db.collection('checks').insertOne({
       createdAt: new Date(),
       linkId: link._id,
+      state: 'finished',
       location: 'http://example.org/8'
     })
 
@@ -144,8 +146,23 @@ describe('jobs.check.check', () => {
       setTimeout(() => resolve(), 2000)
     })
 
-    const check = await createCheck(link, 'http://example.org/8', {})
+    const check = await createCheck(link, 'http://example.org/8')
 
     expect(check.state).toBe('skipped')
+  })
+
+  it('should set noCache to true if the lastCheck is errored', async () => {
+    const link = {_id: new mongo.ObjectID()}
+
+    await mongo.db.collection('checks').insertOne({
+      createdAt: new Date(),
+      linkId: link._id,
+      state: 'errored',
+      location: 'http://example.org/9'
+    })
+
+    const check = await createCheck(link, 'http://example.org/9', {})
+
+    expect(check.options.noCache).toBe(true)
   })
 })

--- a/__tests__/unit/jobs/check/utils/skip.js
+++ b/__tests__/unit/jobs/check/utils/skip.js
@@ -1,0 +1,50 @@
+const cacheControl = require('@tusbar/cache-control')
+const {subSeconds, subDays} = require('date-fns')
+
+const {shouldSkip} = require('../../../../../jobs/check/utils/skip')
+
+describe('jobs.check.utils.skip', () => {
+  it('should skip check if Cache-Control is immutable', () => {
+    const skip = shouldSkip({
+      cacheControl: cacheControl.format({immutable: true})
+    }, {})
+
+    expect(skip).toBe(true)
+  })
+
+  it('should skip check if Cache-Control is not expired', () => {
+    const skip = shouldSkip({
+      cacheControl: cacheControl.format({maxAge: 1000})
+    }, {
+      createdAt: new Date()
+    })
+
+    expect(skip).toBe(true)
+  })
+
+  it('should not skip check if Cache-Control is expired', () => {
+    const skip = shouldSkip({
+      cacheControl: cacheControl.format({maxAge: 1000})
+    }, {
+      createdAt: subSeconds(new Date(), 1100)
+    })
+
+    expect(skip).toBe(false)
+  })
+
+  it('should skip check if last check is not older than 7 days', () => {
+    const skip = shouldSkip({}, {
+      createdAt: subDays(new Date(), 4)
+    })
+
+    expect(skip).toBe(true)
+  })
+
+  it('should not skip check if last check is older than 7 days', () => {
+    const skip = shouldSkip({}, {
+      createdAt: subDays(new Date(), 8)
+    })
+
+    expect(skip).toBe(false)
+  })
+})

--- a/jobs/check/utils/skip.js
+++ b/jobs/check/utils/skip.js
@@ -1,0 +1,19 @@
+const {differenceInSeconds, differenceInDays} = require('date-fns')
+const cacheControl = require('@tusbar/cache-control')
+
+function shouldSkip(link, lastCheck) {
+  const now = new Date()
+
+  if (link.cacheControl) {
+    const cc = cacheControl.parse(link.cacheControl)
+    if (cc.immutable || differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge) {
+      return true
+    }
+  } else if (differenceInDays(now, lastCheck.createdAt) < 7) {
+    return true
+  }
+
+  return false
+}
+
+module.exports = {shouldSkip}


### PR DESCRIPTION
For links that expose `Cache-Control` headers, the `max-age` property is used instead of the 7 days default.

This will prevent too frequent checks/downloads on links that do not support any caching headers (`Etag` or `Last-Modified`).