### PR TITLE
Fallback to 7 days cache when no max-age is defined

### DIFF
--- a/__tests__/unit/jobs/check/utils/skip.js
+++ b/__tests__/unit/jobs/check/utils/skip.js
@@ -32,6 +32,16 @@ describe('jobs.check.utils.skip', () => {
     expect(skip).toBe(false)
   })
 
+  it('should not use Cache-Control if maxAge or imutable is not defined', () => {
+    const skip = shouldSkip({
+      cacheControl: cacheControl.format({private: true})
+    }, {
+      createdAt: subDays(new Date(), 6)
+    })
+
+    expect(skip).toBe(true)
+  })
+
   it('should skip check if last check is not older than 7 days', () => {
     const skip = shouldSkip({}, {
       createdAt: subDays(new Date(), 4)

--- a/jobs/check/utils/skip.js
+++ b/jobs/check/utils/skip.js
@@ -6,14 +6,19 @@ function shouldSkip(link, lastCheck) {
 
   if (link.cacheControl) {
     const cc = cacheControl.parse(link.cacheControl)
-    if (cc.immutable || differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge) {
+    if (cc.immutable) {
       return true
     }
-  } else if (differenceInDays(now, lastCheck.createdAt) < 7) {
-    return true
+
+    if (cc.maxAge) {
+      return differenceInSeconds(now, lastCheck.createdAt) < cc.maxAge
+    }
+
+    // If the Cache-Control header does not include `immutable` or `max-age`,
+    // fall back to the 7 days cache.
   }
 
-  return false
+  return differenceInDays(now, lastCheck.createdAt) < 7
 }
 
 module.exports = {shouldSkip}


### PR DESCRIPTION
Only use `Cache-Control` skips when `immutable` or `max-age` are set.

Otherwise, fallback to 7 days cache.